### PR TITLE
Fix an issue with 'account' page. Make 'login' page configurable

### DIFF
--- a/include/avz.hrl
+++ b/include/avz.hrl
@@ -1,6 +1,6 @@
 -record(struct, {lst=[]}).
 -define(AFTER_LOGIN, wf:config(avz,after_login_page,"/account")).
--define(LOGIN_PAGE, "/login").
+-define(LOGIN_PAGE, wf:config(avz,login_page,"/login")).
 -define(METHODS, [facebook,google,github,twitter,microsoft]).
 -define(API,[sdk/0,               % JavaScript for page embedding for JavaScript based login methods
              login_button/0,      % HTML Button for page embedding

--- a/include/avz.hrl
+++ b/include/avz.hrl
@@ -1,5 +1,5 @@
 -record(struct, {lst=[]}).
--define(AFTER_LOGIN, case wf:config(login) of unknown -> "/account"; P -> P end).
+-define(AFTER_LOGIN, wf:config(avz,after_login_page,"/account")).
 -define(LOGIN_PAGE, "/login").
 -define(METHODS, [facebook,google,github,twitter,microsoft]).
 -define(API,[sdk/0,               % JavaScript for page embedding for JavaScript based login methods


### PR DESCRIPTION
Hello guys.
I faced with non-working redirect to the 'account' page.
The problem is with the following: when it does wf:config(something) it returns [] but not 'undefined'. So, the original code in avz.hrl doesn't work as expected actually. ?AFTER_LOGIN is always [] - at least, for n2k 1.10 (and 1.8 for likely as well).
I changed the code a little and it works now as expected.
I would like also to suggest to make 'login' page configurable as well.
Thanks
