### PR TITLE
Get user cover image URL during login/registration

### DIFF
--- a/priv/facebook_sdk.dtl
+++ b/priv/facebook_sdk.dtl
@@ -7,7 +7,7 @@ window.fbAsyncInit = function() {
       var inIframe= top!=self;
   //    setFbIframe(inIframe);
       if(inIframe && response.status == 'connected' && fbLogin)
-        FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){ fbLogin(response);});
+        FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){ fbLogin(response);});
   //  }
   });
 };
@@ -15,9 +15,9 @@ window.fbAsyncInit = function() {
 function fb_login(){
   FB.getLoginStatus(function(response){
     if(response.status == 'connected'){
-      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
     } else FB.login(function(r){
-        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
       }, {scope: 'email,user_birthday'});
   });
 }

--- a/src/facebook.erl
+++ b/src/facebook.erl
@@ -32,7 +32,8 @@ registration_data(Props, facebook, Ori)->
                 tokens = [{facebook,Id}|Ori#user.tokens],
                 birth = {element(3, BirthDay), element(1, BirthDay), element(2, BirthDay)},
                 register_date = erlang:now(),
-                status = ok }.
+                status = ok,
+                cover = proplists:get_value(<<"source">>, (proplists:get_value(<<"cover">>, Props))#struct.lst) }.
 
 email_prop(Props, _) -> proplists:get_value(<<"email">>, Props).
 


### PR DESCRIPTION
In the pull request #19 to KVS, I've added a new field to the 'user' record - 'cover'. It is supposed to be used for storing user profile's cover image. 
This change adds the feature to AVZ - it will get and store cover image URL during login/registration process.
