### PR TITLE
Facebook cover image, adapting to KVS user record changes, upgrading FB API

### DIFF
--- a/priv/facebook_sdk.dtl
+++ b/priv/facebook_sdk.dtl
@@ -7,7 +7,7 @@ window.fbAsyncInit = function() {
       var inIframe= top!=self;
   //    setFbIframe(inIframe);
       if(inIframe && response.status == 'connected' && fbLogin)
-        FB.api("/me?fields=id,first_name,last_name,email,birthday", function(response){ fbLogin(response);});
+        FB.api("/me?fields=id,first_name,last_name,email,birthday,cover", function(response){ fbLogin(response);});
   //  }
   });
 };
@@ -15,9 +15,9 @@ window.fbAsyncInit = function() {
 function fb_login(){
   FB.getLoginStatus(function(response){
     if(response.status == 'connected'){
-      if(fbLogin) FB.api("/me?fields=id,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+      if(fbLogin) FB.api("/me?fields=id,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
     } else FB.login(function(r){
-        if(r.authResponse && fbLogin) FB.api("/me?fields=id,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+        if(r.authResponse && fbLogin) FB.api("/me?fields=id,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
       }, {scope: 'email,user_birthday'});
   });
 }

--- a/priv/facebook_sdk.dtl
+++ b/priv/facebook_sdk.dtl
@@ -7,7 +7,7 @@ window.fbAsyncInit = function() {
       var inIframe= top!=self;
   //    setFbIframe(inIframe);
       if(inIframe && response.status == 'connected' && fbLogin)
-        FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){ fbLogin(response);});
+        FB.api("/me?fields=id,first_name,last_name,email,birthday", function(response){ fbLogin(response);});
   //  }
   });
 };
@@ -15,9 +15,9 @@ window.fbAsyncInit = function() {
 function fb_login(){
   FB.getLoginStatus(function(response){
     if(response.status == 'connected'){
-      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+      if(fbLogin) FB.api("/me?fields=id,first_name,last_name,email,birthday", function(response){fbLogin(response);});
     } else FB.login(function(r){
-        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+        if(r.authResponse && fbLogin) FB.api("/me?fields=id,first_name,last_name,email,birthday", function(response){fbLogin(response);});
       }, {scope: 'email,user_birthday'});
   });
 }

--- a/priv/facebook_sdk.dtl
+++ b/priv/facebook_sdk.dtl
@@ -7,7 +7,7 @@ window.fbAsyncInit = function() {
       var inIframe= top!=self;
   //    setFbIframe(inIframe);
       if(inIframe && response.status == 'connected' && fbLogin)
-        FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){ fbLogin(response);});
+        FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){ fbLogin(response);});
   //  }
   });
 };
@@ -15,9 +15,9 @@ window.fbAsyncInit = function() {
 function fb_login(){
   FB.getLoginStatus(function(response){
     if(response.status == 'connected'){
-      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
+      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
     } else FB.login(function(r){
-        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
+        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
       }, {scope: 'email,user_birthday'});
   });
 }

--- a/priv/facebook_sdk.dtl
+++ b/priv/facebook_sdk.dtl
@@ -7,7 +7,7 @@ window.fbAsyncInit = function() {
       var inIframe= top!=self;
   //    setFbIframe(inIframe);
       if(inIframe && response.status == 'connected' && fbLogin)
-        FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){ fbLogin(response);});
+        FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){ fbLogin(response);});
   //  }
   });
 };
@@ -15,9 +15,9 @@ window.fbAsyncInit = function() {
 function fb_login(){
   FB.getLoginStatus(function(response){
     if(response.status == 'connected'){
-      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+      if(fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
     } else FB.login(function(r){
-        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday", function(response){fbLogin(response);});
+        if(r.authResponse && fbLogin) FB.api("/me?fields=id,username,first_name,last_name,email,birthday,cover", function(response){fbLogin(response);});
       }, {scope: 'email,user_birthday'});
   });
 }

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {deps_dir, ["deps"]}.
 {deps, [
     {n2o,           ".*", {git, "git://github.com/5HT/n2o", {tag,"2.1"}}},
-    {kvs,           ".*", {git, "git://github.com/synrc/kvs", {tag,"2.1"}}},
+    {kvs,           ".*", {git, "git://github.com/synrc/kvs", {tag,"master"}}},
     {erlydtl,       ".*", {git, "git://github.com/evanmiller/erlydtl.git", {tag,"0.8.0"}}}
 ]}.
 {erlydtl_opts, [

--- a/src/facebook.erl
+++ b/src/facebook.erl
@@ -32,7 +32,8 @@ registration_data(Props, facebook, Ori)->
                 tokens = [{facebook,Id}|Ori#user.tokens],
                 birth = {element(3, BirthDay), element(1, BirthDay), element(2, BirthDay)},
                 register_date = erlang:now(),
-                status = ok }.
+                status = ok,
+                cover = proplists:get_value(<<"source">>, (proplists:get_value(<<"cover">>, Props))#struct.lst) }.
 
 email_prop(Props, _) -> proplists:get_value(<<"email">>, Props).
 

--- a/src/facebook.erl
+++ b/src/facebook.erl
@@ -15,7 +15,6 @@ api_event(fbLogin, Args, _Term)-> JSArgs = n2o_json:decode(Args), avz:login(face
 
 registration_data(Props, facebook, Ori)->
     Id = proplists:get_value(<<"id">>, Props),
-    UserName = binary_to_list(proplists:get_value(<<"username">>, Props)),
     BirthDay = case proplists:get_value(<<"birthday">>, Props) of
         undefined -> {1, 1, 1970};
         BD -> list_to_tuple([list_to_integer(X) || X <- string:tokens(binary_to_list(BD), "/")]) end,
@@ -23,9 +22,10 @@ registration_data(Props, facebook, Ori)->
     error_logger:info_msg("Props: ~p",[Props]),
     Id = proplists:get_value(<<"id">>, Props),
     Email = email_prop(Props, facebook),
+    [UserName|_] = string:tokens(binary_to_list(Email),"@"), Cover = case proplists:get_value(<<"cover">>,Props) of undefined -> ""; P -> case proplists:get_value(<<"source">>,P#struct.lst) of undefined -> ""; C -> binary_to_list(C) end end,
     Ori#user{   id = Email,
                 display_name = UserName,
-                avatar = "https://graph.facebook.com/" ++ UserName ++ "/picture",
+                images = [{fb_avatar,"https://graph.facebook.com/" ++ binary_to_list(Id) ++ "/picture"},{fb_cover,Cover}|Ori#user.images],
                 email = Email,
                 names = proplists:get_value(<<"first_name">>, Props),
                 surnames = proplists:get_value(<<"last_name">>, Props),

--- a/src/facebook.erl
+++ b/src/facebook.erl
@@ -20,7 +20,6 @@ registration_data(Props, facebook, Ori)->
         BD -> list_to_tuple([list_to_integer(X) || X <- string:tokens(binary_to_list(BD), "/")]) end,
     error_logger:info_msg("User Ori: ~p",[Ori]),
     error_logger:info_msg("Props: ~p",[Props]),
-    Id = proplists:get_value(<<"id">>, Props),
     Email = email_prop(Props, facebook),
     [UserName|_] = string:tokens(binary_to_list(Email),"@"), Cover = case proplists:get_value(<<"cover">>,Props) of undefined -> ""; P -> case proplists:get_value(<<"source">>,P#struct.lst) of undefined -> ""; C -> binary_to_list(C) end end,
     Ori#user{   id = Email,

--- a/src/facebook.erl
+++ b/src/facebook.erl
@@ -32,8 +32,7 @@ registration_data(Props, facebook, Ori)->
                 tokens = [{facebook,Id}|Ori#user.tokens],
                 birth = {element(3, BirthDay), element(1, BirthDay), element(2, BirthDay)},
                 register_date = erlang:now(),
-                status = ok,
-                cover = proplists:get_value(<<"source">>, (proplists:get_value(<<"cover">>, Props))#struct.lst) }.
+                status = ok }.
 
 email_prop(Props, _) -> proplists:get_value(<<"email">>, Props).
 

--- a/src/github.erl
+++ b/src/github.erl
@@ -54,7 +54,7 @@ registration_data(Props, github, Ori) ->
     Ori#user{   id= Email,
                 username = binary_to_list(proplists:get_value(<<"login">>, Props)),
                 display_name = Name,
-                avatar = proplists:get_value(<<"avatar_url">>, Props),
+                images = [{gh_avatar,proplists:get_value(<<"avatar_url">>, Props)}|Ori#user.images],
                 email = Email,
                 names  = Name,
                 surnames = [],

--- a/src/google.erl
+++ b/src/google.erl
@@ -19,7 +19,7 @@ registration_data(Props, google, Ori)->
     Email = proplists:get_value(<<"email">>,Props),
     Ori#user{   id = Email,
                 display_name = proplists:get_value(<<"displayName">>, Props),
-                avatar = Image,
+                images = [{google_avatar,Image}|Ori#user.images],
                 email = Email,
                 names = GivenName,
                 surnames = FamilyName,

--- a/src/twitter.erl
+++ b/src/twitter.erl
@@ -16,7 +16,7 @@ registration_data(Props, twitter, Ori)->
     Ori#user{   id = Email,
                 username = re:replace(UserName, "\\.", "_", [{return, list}]),
                 display_name = proplists:get_value(<<"screen_name">>, Props),
-                avatar = proplists:get_value(<<"profile_image_url">>, Props),
+                images = [{tw_avatar,proplists:get_value(<<"profile_image_url">>, Props)}|Ori#user.images],
                 names = proplists:get_value(<<"name">>, Props),
                 email = Email,
                 surnames = [],


### PR DESCRIPTION
1. 'username' field is deprecated in new FB API. Old API is alive till end of April. In the new API, FB returns error when you asking an access to 'username' user property. Originally, username was used for display_name. Now, we construct display_name from 'email' property.

2. Facebook has at least two images for a user profile: avatar and cover image. In the original KVS user record, there was 'avatar' field and wasn't a field for placing cover image. You renamed 'avatar' to 'images', so the next change makes AVZ storing social images in the new field. For instance, FB avatar and FB cover now can be accessible like: Avatar = proplists:get_value(fb_avatar, U#user.images) and Cover = proplists:get_value(fb_cover, U#user.images) and so on.
