### PR TITLE
fix compatibility with n2o 2.8

### DIFF
--- a/src/avz.erl
+++ b/src/avz.erl
@@ -28,6 +28,7 @@ api_event(Name, Args, Term)      -> error_logger:info_msg("Unknown API event: ~p
 login_user(User) -> wf:user(User), wf:redirect(?AFTER_LOGIN).
 login(_Key, [{error, E}|_Rest])-> error_logger:info_msg("oauth error: ~p", [E]);
 login(Key, Args) ->
+    n2o_session:ensure_sid([],?CTX,[]),
     wf:info("AVZ MODULE: ~p",[?CTX#cx.module]),
     case kvs:get(user,Key:email_prop(Args,Key)) of
         {ok,Existed} ->


### PR DESCRIPTION
AVZ login was broken from n2o 2.4. This patch introduces compatibility with n2o 2.4 (tested up to 2.8).
