### PR TITLE
Fix update users and merge tokens

### DIFF
--- a/src/avz.erl
+++ b/src/avz.erl
@@ -8,9 +8,7 @@
 sha(Pass) -> crypto:hmac(wf:config(n2o,hmac,sha256),n2o_secret:secret(),wf:to_binary(Pass)).
 update({K,V},P) -> wf:setkey(K,1,case P of undefined -> []; _P -> _P end,{K,V}).
 
-coalesce(undefined,Y) -> Y;
-coalesce(X,        _) -> X.
-
+coalesce(_,Y) -> Y.
 merge(A,B) -> list_to_tuple([ coalesce(X,Y) || {X,Y} <- lists:zip(tuple_to_list(A),tuple_to_list(B)) ]).
 
 callbacks(Methods) -> [ M:callback()     || M <- Methods].

--- a/src/facebook.erl
+++ b/src/facebook.erl
@@ -29,7 +29,7 @@ registration_data(Props, facebook, Ori)->
                 email = Email,
                 names = proplists:get_value(<<"first_name">>, Props),
                 surnames = proplists:get_value(<<"last_name">>, Props),
-                tokens = avz:merge({facebook,Id},Ori#user.tokens),
+                tokens = avz:update({facebook,Id},Ori#user.tokens),
                 birth = {element(3, BirthDay), element(1, BirthDay), element(2, BirthDay)},
                 register_date = os:timestamp(),
                 status = ok }.


### PR DESCRIPTION
1. update users
when we do avz:merge(User1, User2) - we should prefer User2's new data rather than leaving old User1's fields

2. fix merge facebook tokens
seems, we should use avz:update for tokens rather than avz:merge - otherwise, we have 'bad argument' error and broken facebook login